### PR TITLE
P0 change

### DIFF
--- a/ztfperiodic/simulate.py
+++ b/ztfperiodic/simulate.py
@@ -200,7 +200,7 @@ def pdot_phasefold(times, P, Pdot, t0=0):
 
 
 def pdot_lc(t_obs, mag=None, absmag=True, d=None, Pdot=None, radius_1=None, radius_2=None, sbratio=sbratio, incl=i, 
-       light_3 = 0, t_zero = 0, period = P0, a=None, q = m1/m2, 
+       light_3 = 0, t_zero = 0, period = P0, a=None, q = m1/m2, m_tot = m1 + m2,
        f_c = None, f_s = None,
        ldc_1 = None, ldc_2 = None,
        gdc_1 = None, gdc_2 = None,
@@ -265,8 +265,11 @@ def pdot_lc(t_obs, mag=None, absmag=True, d=None, Pdot=None, radius_1=None, radi
     
     fluxes = []
     tmods = []
+
     P0 = period
-    
+    m1 = m_tot/(1+q)
+    m2 = m_tot*q/(1+q)
+       
     # calculate semi major axis
     if a is None:
         p_sec = P0*24*3600 # convert units from days to sec    


### PR DESCRIPTION
I added a few quick changes. The lines added were for the sole reason that when using P0, m1, m2 within the function, these values were all set according to the defaults at the top of the script. For example, the function is called with period = P0, so period will be set to the value you input. But then throughout the function you call the value P0 which will just be equal to the default at 0.005. Now,  P0 will change with the entered period, m1 and m2 will change based on entered q and m_tot.